### PR TITLE
Fix GXDateTime formatting for certain locales.

### DIFF
--- a/development/src/GXDateTime.cpp
+++ b/development/src/GXDateTime.cpp
@@ -239,7 +239,7 @@ int GetDateFormat(GXDLMS_DATE_FORMAT& format, char& separator)
     order.tm_year = 0;
     order.tm_mday = 1;
     order.tm_mon = 1;//Month is zero based.
-    ret = strftime(buff, 10, "%x", &order);
+    ret = strftime(buff, 11, "%x", &order);
     if (ret > 0)
     {
         for (pos = 0; pos != ret; ++pos)


### PR DESCRIPTION
The date in locales having the full four digit year as the preferred
date representation can be up to 10 char long.

strftime(3) size argument is supposed to include the terminating null
byte as well.
