### PR TITLE
Missing return in CGXDLMSImageTransfer::GetValue()

### DIFF
--- a/development/src/GXDLMSImageTransfer.cpp
+++ b/development/src/GXDLMSImageTransfer.cpp
@@ -315,6 +315,7 @@ int CGXDLMSImageTransfer::GetValue(CGXDLMSSettings& settings, CGXDLMSValueEventA
 			}
 		}
 		e.SetValue(data);
+		return DLMS_ERROR_CODE_OK;
 	}
 	return DLMS_ERROR_CODE_INVALID_PARAMETER;
 }


### PR DESCRIPTION
Reading index 7 of GXDLMSImageTransfer was returning access error.

...
-------- Reading GXDLMSImageTransfer 0.0.44.0.0.255 Manufacturer specific
Index: 2 Value: 200
Index: 3 Value: 
Index: 4 Value: 0
Index: 5 Value: true
Index: 6 Value: IMAGE_TRANSFER_NOT_INITIATED
Error! Index: 7 Access Error : Device reports a hardware fault.
...

Regards,
Roman