### PR TITLE
Add creation of obj/bin directories or build will fail. 

### DIFF
--- a/GuruxDLMSClientExample/makefile
+++ b/GuruxDLMSClientExample/makefile
@@ -21,23 +21,26 @@ SOURCES  := $(wildcard $(SRCDIR)/*.cpp)
 INCLUDES := $(wildcard $(SRCDIR)/*.h)
 
 OBJECTS  := $(SOURCES:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
-rm       = rm -f
+rm       = rm -rf
+mkdir    = mkdir -p
 
 $(BINDIR)/$(TARGET): $(OBJECTS)
+	@$(mkdir) $(BINDIR)
 	@$(LINKER) $@ $(LFLAGS) $(OBJECTS) -lgurux_dlms_cpp
 	@echo "Linking complete!"
 
 $(OBJECTS): $(OBJDIR)/%.o : $(SRCDIR)/%.cpp
+	@$(mkdir) $(OBJDIR)
 	@$(CC) $(CFLAGS) -c $< -o $@
 	@echo "Compiled "$<" successfully!"
 
 .PHONEY: clean
 clean:
-	@$(rm) $(OBJECTS)
+	@$(rm) $(OBJDIR)
 	@echo "Cleanup complete!" 
 	@echo $(OBJECTS)
 
 .PHONEY: remove
 remove: clean
-	@$(rm) $(BINDIR)/$(TARGET)
+	@$(rm) $(BINDIR)
 	@echo "Executable removed!"

--- a/GuruxDLMSPushExample/makefile
+++ b/GuruxDLMSPushExample/makefile
@@ -21,23 +21,26 @@ SOURCES  := $(wildcard $(SRCDIR)/*.cpp)
 INCLUDES := $(wildcard $(SRCDIR)/*.h)
 
 OBJECTS  := $(SOURCES:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
-rm       = rm -f
+rm       = rm -rf
+mkdir    = mkdir -p
 
 $(BINDIR)/$(TARGET): $(OBJECTS)
+	@$(mkdir) $(BINDIR)
 	@$(LINKER) $@ $(LFLAGS) $(OBJECTS) -lgurux_dlms_cpp -lpthread
 	@echo "Linking complete!"
 
 $(OBJECTS): $(OBJDIR)/%.o : $(SRCDIR)/%.cpp
+	@$(mkdir) $(OBJDIR)
 	@$(CC) $(CFLAGS) -c $< -o $@
 	@echo "Compiled "$<" successfully!"
 
 .PHONEY: clean
 clean:
-	@$(rm) $(OBJECTS)
+	@$(rm) $(OBJDIR)
 	@echo "Cleanup complete!" 
 	@echo $(OBJECTS)
 
 .PHONEY: remove
 remove: clean
-	@$(rm) $(BINDIR)/$(TARGET)
+	@$(rm) $(BINDIR)
 	@echo "Executable removed!"

--- a/GuruxDLMSServerExample/makefile
+++ b/GuruxDLMSServerExample/makefile
@@ -21,23 +21,26 @@ SOURCES  := $(wildcard $(SRCDIR)/*.cpp)
 INCLUDES := $(wildcard $(SRCDIR)/*.h)
 
 OBJECTS  := $(SOURCES:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
-rm       = rm -f
+rm       = rm -rf
+mkdir    = mkdir -p
 
 $(BINDIR)/$(TARGET): $(OBJECTS)
+	@$(mkdir) $(BINDIR)
 	@$(LINKER) $@ $(LFLAGS) $(OBJECTS) -lgurux_dlms_cpp -lpthread
 	@echo "Linking complete!"
 
 $(OBJECTS): $(OBJDIR)/%.o : $(SRCDIR)/%.cpp
+	@$(mkdir) $(OBJDIR)
 	@$(CC) $(CFLAGS) -c $< -o $@
 	@echo "Compiled "$<" successfully!"
 
 .PHONEY: clean
 clean:
-	@$(rm) $(OBJECTS)
+	@$(rm) $(OBJDIR)
 	@echo "Cleanup complete!" 
 	@echo $(OBJECTS)
 
 .PHONEY: remove
 remove: clean
-	@$(rm) $(BINDIR)/$(TARGET)
+	@$(rm) $(BINDIR)
 	@echo "Executable removed!"


### PR DESCRIPTION
This PR is similar to #14 but applied to example applications. If obj/ and bin/ directories are not there the build will fail, so make sure we create them.
Also cleanup (clean and remove targets) is more complete now, removing all contents and the directories themselves.