### PR TITLE
Make library compatible with C++03 standard so it works also with older compilers

### DIFF
--- a/development/include/GXDLMSAssociationLogicalName.h
+++ b/development/include/GXDLMSAssociationLogicalName.h
@@ -62,7 +62,7 @@ private:
 
     std::string m_SecuritySetupReference;
 
-    std::vector<std::pair<unsigned char, std::string>> m_UserList;
+    std::vector<std::pair<unsigned char, std::string> > m_UserList;
 
     std::pair<unsigned char, std::string> m_CurrentUser;
 
@@ -120,9 +120,9 @@ public:
 
     void SetSecret(CGXByteBuffer& value);
 
-    std::vector<std::pair<unsigned char, std::string>>& GetUserList();
+    std::vector<std::pair<unsigned char, std::string> >& GetUserList();
 
-    void SetUserList(std::vector<std::pair<unsigned char, std::string>>& value);
+    void SetUserList(std::vector<std::pair<unsigned char, std::string> >& value);
 
     std::pair<unsigned char, std::string>& GetCurrentUser();
 

--- a/development/src/GXDLMSAssociationLogicalName.cpp
+++ b/development/src/GXDLMSAssociationLogicalName.cpp
@@ -323,12 +323,12 @@ void CGXDLMSAssociationLogicalName::SetSecret(CGXByteBuffer& value)
     m_Secret = value;
 }
 
-std::vector<std::pair<unsigned char, std::string>>& CGXDLMSAssociationLogicalName::GetUserList()
+std::vector<std::pair<unsigned char, std::string> >& CGXDLMSAssociationLogicalName::GetUserList()
 {
     return m_UserList;
 }
 
-void CGXDLMSAssociationLogicalName::SetUserList(std::vector<std::pair<unsigned char, std::string>>& value)
+void CGXDLMSAssociationLogicalName::SetUserList(std::vector<std::pair<unsigned char, std::string> >& value)
 {
     m_UserList = value;
 }


### PR DESCRIPTION
This PR makes minor changes that enable the code to be compiled also with C++03 standard compilers (of course as well as newer ones) for example the still quite used:

> g++ (Ubuntu 4.8.4-2ubuntu1~14.04.4) 4.8.4

Basically it's syntax details on how to write templates inside templates.

I tested this on Linux, please check out under Windows systems.
