### PR TITLE
Handle client side framecounter correctly

### DIFF
--- a/development/src/GXCipher.cpp
+++ b/development/src/GXCipher.cpp
@@ -773,7 +773,7 @@ int CGXCipher::Decrypt(
     {
         return ret;
     }
-    m_FrameCounter = frameCounter + 1;
+    m_FrameCounter = m_FrameCounter + 1;
     if (security == DLMS_SECURITY_AUTHENTICATION)
     {
         length = (unsigned short)(data.m_Size - data.m_Position - 12);


### PR DESCRIPTION
increment the client-side frame counter instead of setting it to the server-side framecounter+1.  devices should maintain two counters, one for RX and one for TX.  these should be kept separate in the client.  this change has not been tested if used on the server side, only on the client side.