### PR TITLE
Use bitwise & rather than boolean && to check getConnected() state.

### DIFF
--- a/GuruxDLMSClientExample/src/communication.cpp
+++ b/GuruxDLMSClientExample/src/communication.cpp
@@ -43,7 +43,7 @@ void CGXCommunication::WriteValue(GX_TRACE_LEVEL trace, std::string line)
 {
     if (trace > GX_TRACE_LEVEL_WARNING)
     {
-        printf(line.c_str());
+        printf("%s", line.c_str());
     }
     GXHelpers::Write("LogFile.txt", line);
 }
@@ -912,7 +912,7 @@ int CGXCommunication::UpdateFrameCounter()
         {
             m_Parser->GetCiphering()->SetInvocationCounter(1 + d.GetValue().ToInteger());
         }
-        printf("Invocation counter: %d\n", m_Parser->GetCiphering()->GetInvocationCounter());
+        printf("Invocation counter: %ld\n", m_Parser->GetCiphering()->GetInvocationCounter());
         reply.Clear();
         Disconnect();
         m_Parser->SetClientAddress(add);

--- a/development/src/GXDLMSLNCommandHandler.cpp
+++ b/development/src/GXDLMSLNCommandHandler.cpp
@@ -482,7 +482,7 @@ int CGXDLMSLNCommandHandler::HandleGetRequest(
     unsigned char cipheredCommand)
 {
     // Return error if connection is not established.
-    if (xml == NULL && (settings.GetConnected() && DLMS_CONNECTION_STATE_DLMS) == 0 &&
+    if (xml == NULL && (settings.GetConnected() & DLMS_CONNECTION_STATE_DLMS) == 0 &&
         cipheredCommand == DLMS_COMMAND_NONE)
     {
         server->GenerateConfirmedServiceError(DLMS_CONFIRMED_SERVICE_ERROR_INITIATE_ERROR,
@@ -992,7 +992,7 @@ int CGXDLMSLNCommandHandler::HandleSetRequest(
     CGXDataInfo i;
     CGXByteBuffer bb;
     // Return error if connection is not established.
-    if (xml == NULL && (settings.GetConnected() && DLMS_CONNECTION_STATE_DLMS) == 0)
+    if (xml == NULL && (settings.GetConnected() & DLMS_CONNECTION_STATE_DLMS) == 0)
     {
         server->GenerateConfirmedServiceError(DLMS_CONFIRMED_SERVICE_ERROR_INITIATE_ERROR,
             DLMS_SERVICE_ERROR_SERVICE, DLMS_SERVICE_UNSUPPORTED,

--- a/development/src/GXDLMSSNCommandHandler.cpp
+++ b/development/src/GXDLMSSNCommandHandler.cpp
@@ -155,7 +155,7 @@ int CGXDLMSSNCommandHandler::HandleWriteRequest(
     unsigned char cipheredCommand)
 {
     // Return error if connection is not established.
-    if (xml == NULL && (settings.GetConnected() && DLMS_CONNECTION_STATE_DLMS) == 0)
+    if (xml == NULL && (settings.GetConnected() & DLMS_CONNECTION_STATE_DLMS) == 0)
     {
         server->GenerateConfirmedServiceError(DLMS_CONFIRMED_SERVICE_ERROR_INITIATE_ERROR,
             DLMS_SERVICE_ERROR_SERVICE,


### PR DESCRIPTION
The Java source and most of the other places in the C++ code treat
these as bit flags, so this makes the usage consistent.