### PR TITLE
Correct letters case in include of GXBytebuffer.h

### DIFF
--- a/development/include/GXDLMSPlcMeterInfo.h
+++ b/development/include/GXDLMSPlcMeterInfo.h
@@ -36,7 +36,7 @@
 #define GXDLMSPLCMETERINFO_H
 
 #include "enums.h"
-#include "GXByteBuffer.h"
+#include "GXBytebuffer.h"
 
 //Information from the discovered PLC meter(s).
 class CGXDLMSPlcMeterInfo

--- a/development/include/GXPlcSettings.h
+++ b/development/include/GXPlcSettings.h
@@ -37,7 +37,7 @@
 
 #include <vector>
 #include "enums.h"
-#include "GXByteBuffer.h"
+#include "GXBytebuffer.h"
 #include "GXDLMSPlcRegister.h"
 #include "GXDLMSPlcMeterInfo.h"
 


### PR DESCRIPTION
This makes sources compilable with gcc as it uses case sensetive includes.