### PR TITLE
Use bitwise & rather than boolean && to check getConnected() state

### DIFF
--- a/development/src/GXDLMSLNCommandHandler.cpp
+++ b/development/src/GXDLMSLNCommandHandler.cpp
@@ -494,7 +494,7 @@ int CGXDLMSLNCommandHandler::HandleGetRequest(
     unsigned char cipheredCommand)
 {
     // Return error if connection is not established.
-    if (xml == NULL && (settings.GetConnected() && DLMS_CONNECTION_STATE_DLMS) == 0 &&
+    if (xml == NULL && (settings.GetConnected() & DLMS_CONNECTION_STATE_DLMS) == 0 &&
         cipheredCommand == DLMS_COMMAND_NONE)
     {
         server->GenerateConfirmedServiceError(DLMS_CONFIRMED_SERVICE_ERROR_INITIATE_ERROR,
@@ -1026,7 +1026,7 @@ int CGXDLMSLNCommandHandler::HandleSetRequest(
     CGXDataInfo i;
     CGXByteBuffer bb;
     // Return error if connection is not established.
-    if (xml == NULL && (settings.GetConnected() && DLMS_CONNECTION_STATE_DLMS) == 0)
+    if (xml == NULL && (settings.GetConnected() & DLMS_CONNECTION_STATE_DLMS) == 0)
     {
         server->GenerateConfirmedServiceError(DLMS_CONFIRMED_SERVICE_ERROR_INITIATE_ERROR,
             DLMS_SERVICE_ERROR_SERVICE, DLMS_SERVICE_UNSUPPORTED,

--- a/development/src/GXDLMSSNCommandHandler.cpp
+++ b/development/src/GXDLMSSNCommandHandler.cpp
@@ -159,7 +159,7 @@ int CGXDLMSSNCommandHandler::HandleWriteRequest(
     unsigned char cipheredCommand)
 {
     // Return error if connection is not established.
-    if (xml == NULL && (settings.GetConnected() && DLMS_CONNECTION_STATE_DLMS) == 0)
+    if (xml == NULL && (settings.GetConnected() & DLMS_CONNECTION_STATE_DLMS) == 0)
     {
         server->GenerateConfirmedServiceError(DLMS_CONFIRMED_SERVICE_ERROR_INITIATE_ERROR,
             DLMS_SERVICE_ERROR_SERVICE,


### PR DESCRIPTION
This fixes compilation error "enum constant in boolean context [-Werror=int-in-bool-context]"