### PR TITLE
[FIX] Get pointer to pointer instead of pointer. Always true.

### DIFF
--- a/development/src/GXDLMSLNCommandHandler.cpp
+++ b/development/src/GXDLMSLNCommandHandler.cpp
@@ -1279,7 +1279,7 @@ int CGXDLMSLNCommandHandler::MethodRequestNextBlock(
     p.SetStreaming(streaming);
     p.SetWindowSize(settings.GetGbtWindowSize());
     //If transaction is not in progress.
-    if (&server->m_Transaction == NULL)
+    if (server->m_Transaction == NULL)
     {
         p.SetStatus(DLMS_ERROR_CODE_NO_LONG_GET_OR_READ_IN_PROGRESS);
     }


### PR DESCRIPTION
`&server->m_Transaction` is pointer to object member. It is always true. We need the pointer, stored in object member `m_Transaction`.