### PR TITLE
Fix incorrect scaler arithmetic in CGXDLMSRegister

### DIFF
--- a/development/src/GXDLMSRegister.cpp
+++ b/development/src/GXDLMSRegister.cpp
@@ -243,7 +243,7 @@ int CGXDLMSRegister::GetValue(CGXDLMSSettings& settings, CGXDLMSValueEventArg& e
             {
                 return ret;
             }
-            tmp = m_Value.dblVal / GetScaler();
+            tmp = m_Value.dblVal * GetScaler();
             if ((ret = tmp.ChangeType(dt)) != 0)
             {
                 return ret;
@@ -278,8 +278,7 @@ int CGXDLMSRegister::SetValue(CGXDLMSSettings& settings, CGXDLMSValueEventArg& e
     {
         if (m_Scaler != 0 && e.GetValue().IsNumber())
         {
-            double val = GetScaler();
-            val *= e.GetValue().ToDouble();
+            double val = e.GetValue().ToDouble() / GetScaler();
             CGXDLMSVariant tmp(val);
             SetValue(tmp);
         }


### PR DESCRIPTION
Problem:
--------
CGXDLMSRegister::GetValue() and SetValue() had inverted scaler operations:
1. GetValue() divided raw value by scaler multiplier (should multiply)
2. SetValue() multiplied scaled value by scaler multiplier (should divide)

This caused incorrect value transmission between client and server.

Changes:
--------
File: src/GXDLMSRegister.cpp

GetValue() :
  - Before: tmp = m_Value.dblVal / GetScaler();
  + After:  tmp = m_Value.dblVal * GetScaler();

SetValue() :
  - Before: val *= e.GetValue().ToDouble();
  + After:  val = e.GetValue().ToDouble() / GetScaler();